### PR TITLE
Fix auto importer from attempting to auto import half-transferred files

### DIFF
--- a/calibre-web-automator/books-to-process-detector.sh
+++ b/calibre-web-automator/books-to-process-detector.sh
@@ -2,7 +2,7 @@
 
 # https://github.com/janeczku/calibre-web/wiki/Automatically-import-new-books-(Linux)
 
-# This script is used to automatically import downloaded eBook's into a Calibre database.
+# This script is used to automatically import downloaded ebooks into a Calibre database.
 # Reference: https://manual.calibre-ebook.com/generated/en/calibredb.html#add
 echo "========== STARTING BOOKS-TO-PROCESS DETECTOR =========="
 
@@ -15,5 +15,5 @@ inotifywait -m -e create -e moved_to "$WATCH_FOLDER" |
 while read -r directory events filename; do
         echo "[books-to-process]: New files detected - $filename"
         python3 /etc/calibre-web-automator/new-book-processor.py
-        echo "[books-to-process]: New files sucsessfully moved/converted, the Ingest Folder has been emptied and is ready to go again."
+        echo "[books-to-process]: New files successfully moved/converted, the Ingest Folder has been emptied and is ready to go again."
 done

--- a/calibre-web-automator/new-book-detector.sh
+++ b/calibre-web-automator/new-book-detector.sh
@@ -24,7 +24,7 @@ add_to_calibre() {
 }
 
 # Monitor the folder for new files
-inotifywait -m -e create -e moved_to "$WATCH_FOLDER" |
+inotifywait -m -e close_write -e moved_to "$WATCH_FOLDER" |
 while read -r directory events filename; do
         echo "[new-book-detector]: New file detected: $filename"
         add_to_calibre "$filename"


### PR DESCRIPTION
Simple fix, just switching the inotify event from create to close_write. [Referenced this stackoverflow post](https://stackoverflow.com/questions/46542819/bash-script-inotifywait-wait-for-file-completely-written-before-proceding). Fixes #7 

I haven't tested it yet though but I'm fairly confident this will fix the problem. [Also edited the wiki page in the main calibre-web repo](https://github.com/janeczku/calibre-web/wiki/Automatically-import-new-books-(Linux))