### PR TITLE
Fully fix auto import from attempting to import half-transferred files; Fix auto import not detecting folders; Fix ingest folders not getting deleted

### DIFF
--- a/calibre-web-automator/books-to-process-detector.sh
+++ b/calibre-web-automator/books-to-process-detector.sh
@@ -11,7 +11,7 @@ WATCH_FOLDER=$(grep -o '"ingest_folder": "[^"]*' /etc/calibre-web-automator/dirs
 echo "[books-to-process]: Watching folder: $WATCH_FOLDER"
 
 # Monitor the folder for new files
-inotifywait -m -e create -e moved_to "$WATCH_FOLDER" |
+inotifywait -m -r -e close_write -e moved_to "$WATCH_FOLDER" |
 while read -r directory events filename; do
         echo "[books-to-process]: New files detected - $filename"
         python3 /etc/calibre-web-automator/new-book-processor.py

--- a/calibre-web-automator/books-to-process-detector.sh
+++ b/calibre-web-automator/books-to-process-detector.sh
@@ -11,9 +11,10 @@ WATCH_FOLDER=$(grep -o '"ingest_folder": "[^"]*' /etc/calibre-web-automator/dirs
 echo "[books-to-process]: Watching folder: $WATCH_FOLDER"
 
 # Monitor the folder for new files
-inotifywait -m -r -e close_write -e moved_to "$WATCH_FOLDER" |
-while read -r directory events filename; do
-        echo "[books-to-process]: New files detected - $filename"
-        python3 /etc/calibre-web-automator/new-book-processor.py
+inotifywait -m -r --format="%e %w%f" -e close_write -e moved_to "$WATCH_FOLDER" |
+while read -r events filepath ; do
+        echo "[books-to-process]: New files detected - $filepath"
+        python3 /etc/calibre-web-automator/new-book-processor.py "$filepath"
         echo "[books-to-process]: New files successfully moved/converted, the Ingest Folder has been emptied and is ready to go again."
 done
+

--- a/calibre-web-automator/metadata-change-detector.sh
+++ b/calibre-web-automator/metadata-change-detector.sh
@@ -7,7 +7,7 @@ WATCH_FOLDER="/etc/calibre-web-automator/metadata_change_logs"
 echo "[metadata-change-detector]: Watching folder: $WATCH_FOLDER"
 
 # Monitor the folder for new files
-inotifywait -m -e create -e moved_to --exclude '^.*\.(swp)$' "$WATCH_FOLDER" |
+inotifywait -m -e close_write -e moved_to --exclude '^.*\.(swp)$' "$WATCH_FOLDER" |
 while read -r directory events filename; do
         echo "[metadata-change-detector]: New file detected: $filename"
         python3 /etc/calibre-web-automator/cover-enforcer.py "--log" "$filename"

--- a/calibre-web-automator/new-book-detector.sh
+++ b/calibre-web-automator/new-book-detector.sh
@@ -24,14 +24,16 @@ add_to_calibre() {
 }
 
 # Monitor the folder for new files
-inotifywait -m -r -e close_write -e moved_to "$WATCH_FOLDER" |
-while read -r directory events filename; do
-        echo "[new-book-detector]: New file detected: $filename"
-        add_to_calibre "$filename"
-        echo "[new-book-detector]: Removing $filename from import folder..."
+inotifywait -m -r --format="%e %w%f" -e close_write -e moved_to "$WATCH_FOLDER" |
+while read -r events filepath; do
+        echo "[new-book-detector]: New file detected: $filepath"
+        add_to_calibre "$filepath"
+        echo "[new-book-detector]: Removing $filepath from import folder..."
         chown -R abc:users "$WATCH_FOLDER"
-        find "$WATCH_FOLDER/" -mindepth 1 -type f,d -delete
+        #find "$WATCH_FOLDER/" -mindepth 1 -type f,d -delete
+        rm "$filepath"
         sleep 10s
         chown -R abc:1000 "$CALIBRE_LIBRARY"
-        echo "[new-book-detector]: $filename successfully moved/converted, the Ingest Folder has been emptied and is ready"
+        echo "[new-book-detector]: $filepath successfully moved/converted, the Ingest Folder has been emptied and is ready"
 done
+

--- a/calibre-web-automator/new-book-detector.sh
+++ b/calibre-web-automator/new-book-detector.sh
@@ -24,14 +24,14 @@ add_to_calibre() {
 }
 
 # Monitor the folder for new files
-inotifywait -m -e close_write -e moved_to "$WATCH_FOLDER" |
+inotifywait -m -r -e close_write -e moved_to "$WATCH_FOLDER" |
 while read -r directory events filename; do
         echo "[new-book-detector]: New file detected: $filename"
         add_to_calibre "$filename"
         echo "[new-book-detector]: Removing $filename from import folder..."
         chown -R abc:users "$WATCH_FOLDER"
-        find "$WATCH_FOLDER/" -type f -delete
+        find "$WATCH_FOLDER/" -mindepth 1 -type f,d -delete
         sleep 10s
         chown -R abc:1000 "$CALIBRE_LIBRARY"
-        echo "[new-book-detector]: $filename successfully moved/converted, the import & ingest folders have been emptied and are ready to go again!"
+        echo "[new-book-detector]: $filename successfully moved/converted, the Ingest Folder has been emptied and is ready"
 done

--- a/calibre-web-automator/new-book-processor.py
+++ b/calibre-web-automator/new-book-processor.py
@@ -3,6 +3,7 @@ import json
 import os
 import sys
 import time
+import shutil
 
 supported_book_formats = ['azw', 'azw3', 'azw4', 'cbz', 'cbr', 'cb7', 'cbc', 'chm', 'djvu', 'docx', 'epub', 'fb2', 'fbz', 'html', 'htmlz', 'lit', 'lrf', 'mobi', 'odt', 'pdf', 'prc', 'pdb', 'pml', 'rb', 'rtf', 'snb', 'tcr', 'txt', 'txtz']
 hierarchy_of_succsess = ['lit', 'mobi', 'azw', 'epub', 'azw3', 'fb2', 'fbz', 'azw4',  'prc', 'odt', 'lrf', 'pdb',  'cbz', 'pml', 'rb', 'cbr', 'cb7', 'cbc', 'chm', 'djvu', 'snb', 'tcr', 'pdf', 'docx', 'rtf', 'html', 'htmlz', 'txtz', 'txt']
@@ -83,9 +84,7 @@ def copy_epubs_for_import(epub_files) -> None:
 
 def empty_to_process_folder() -> None:
     """Empties the ingest folder"""
-    files = glob.glob(f"{ingest_folder}*")
-    for f in files:
-        os.remove(f)
+    shutil.rmtree(ingest_folder)
 
 
 if __name__ == "__main__":

--- a/calibre-web-automator/new-book-processor.py
+++ b/calibre-web-automator/new-book-processor.py
@@ -3,7 +3,8 @@ import json
 import os
 import sys
 import time
-import shutil
+from pathlib import Path
+import subprocess
 
 supported_book_formats = ['azw', 'azw3', 'azw4', 'cbz', 'cbr', 'cb7', 'cbc', 'chm', 'djvu', 'docx', 'epub', 'fb2', 'fbz', 'html', 'htmlz', 'lit', 'lrf', 'mobi', 'odt', 'pdf', 'prc', 'pdb', 'pml', 'rb', 'rtf', 'snb', 'tcr', 'txt', 'txtz']
 hierarchy_of_succsess = ['lit', 'mobi', 'azw', 'epub', 'azw3', 'fb2', 'fbz', 'azw4',  'prc', 'odt', 'lrf', 'pdb',  'cbz', 'pml', 'rb', 'cbr', 'cb7', 'cbc', 'chm', 'djvu', 'snb', 'tcr', 'pdf', 'docx', 'rtf', 'html', 'htmlz', 'txtz', 'txt']
@@ -15,25 +16,30 @@ with open('/etc/calibre-web-automator/dirs.json', 'r') as f:
 # Both folders are assigned by user during setup
 import_folder = f"{dirs['import_folder']}/"
 ingest_folder = f"{dirs['ingest_folder']}/" # Dir where new files are looked for to process and subsequently deleted
+filepath = sys.argv[1] # path of the book we're targeting
 
 def main():
     t_start = time.time()
 
-    new_files = [os.path.join(dirpath,f) for (dirpath, dirnames, filenames) in os.walk(ingest_folder) for f in filenames] 
-    epub_files = [f for f in new_files if f.endswith('.epub')]
+    isEpub = True if filepath.endswith('.epub') else False
 
-    if len(epub_files) == 0: # Books require conversion
+    if not isEpub: # Books require conversion
         print("\n[new-book-processor]: No epub files found in the current directory. Starting conversion process...")
-        files_to_convert, import_format = select_books_for_conversion(new_files)
-        print(f"[new-book-processor]: Converting {len(files_to_convert)} file(s) from to epub format...\n")
-        time_total_conversion = convert_books(files_to_convert, import_format)
-        print(f"\n[new-book-processor]: {len(files_to_convert)} conversion(s) to .epub format completed succsessfully in {time_total_conversion:.2f} seconds.")
-        print("[new-book-processor]: All new epub files have now been moved to the calibre-web import folder.")
+        can_convert, import_format = can_convert()
+        print(f"[new-book-processor]: Converting file from to epub format...\n")
+        
+        if (can_convert):
+            time_total_conversion = convert_book(import_format)
+            print(f"\n[new-book-processor]: conversion to .epub format completed succsessfully in {time_total_conversion:.2f} seconds.")
+            print("[new-book-processor]: All new epub files have now been moved to the calibre-web import folder.")
+        else:
+            print(f"Cannot convert {filepath}")
+            
     else: # Books only need copying to the import folder
-        print(f"\n[new-book-processor]: Found {len(epub_files)} epub file(s) from the most recent download.")
+        print(f"\n[new-book-processor]: Found  epub file from the most recent download.")
         print("[new-book-processor]: Moving resulting files to calibre-web import folder...\n")
-        copy_epubs_for_import(epub_files)
-        print(f"[new-book-processor]: Copied {len(epub_files)} epub file(s) to calibre-web import folder.")
+        move_epub(isEpub)
+        print(f"[new-book-processor]: Copied epub file to calibre-web import folder.")
 
     t_end = time.time()
     running_time = t_end - t_start
@@ -42,18 +48,16 @@ def main():
     empty_to_process_folder()
     sys.exit(1)
 
-def convert_books(files_to_convert, import_format: str) -> float:
+def convert_book(import_format: str) -> float:
     """Uses the following terminal command to convert the books provided using the calibre converter tool:\n\n--- ebook-convert myfile.input_format myfile.output_format\n\nAnd then saves the resulting epubs to the calibre-web import folder."""
     t_convert_total_start = time.time()
-    for file_to_convert in files_to_convert:
-        t_convert_book_start = time.time()
-        book_title = file_to_convert.split('/')[-1]
-        print(f"[new-book-processor]: START_CON: Converting {book_title}...\n")
-        filename = file_to_convert.split('/')[-1]
-        os.system(f'ebook-convert "{file_to_convert}" "{import_folder}{(filename.split(f".{import_format}"))[0]}.epub"')
-        t_convert_book_end = time.time()
-        time_book_conversion = t_convert_book_end - t_convert_book_start
-        print(f"\n[new-book-processor]: END_CON: Conversion of {book_title} complete in {time_book_conversion:.2f} seconds.\n")
+    t_convert_book_start = time.time()
+    filename = filepath.split('/')[-1]
+    print(f"[new-book-processor]: START_CON: Converting {filename}...\n")
+    os.system(f'ebook-convert "{filepath}" "{import_folder}{(filename.split(f".{import_format}"))[0]}.epub"')
+    t_convert_book_end = time.time()
+    time_book_conversion = t_convert_book_end - t_convert_book_start
+    print(f"\n[new-book-processor]: END_CON: Conversion of {filename} complete in {time_book_conversion:.2f} seconds.\n")
 
     t_convert_total_end = time.time()
     time_total_conversion = t_convert_total_end - t_convert_total_start
@@ -61,31 +65,32 @@ def convert_books(files_to_convert, import_format: str) -> float:
     return time_total_conversion
 
 
-def select_books_for_conversion(new_files: list[str]) -> tuple[list[str], str]:
-    """When no epubs are detected in the download, this function will go through the list of new files and check for the format the are in that has the highest chance of sucsessful conversion according to the input format hierarchy list provided by calibre"""
-    files_to_convert = []
+def can_convert():
+    """When no epubs are detected in the download, this function will go through the list of new files 
+    and check for the format the are in that has the highest chance of sucsessful conversion according to the input format hierarchy list 
+    provided by calibre"""
+    can_convert = False
     import_format = ''
     for format in hierarchy_of_succsess:
-        file_search = [f for f in new_files if f.endswith(f'.{format}')]
-        if len(file_search) > 0:
-            files_to_convert += file_search
+        canBeConverted = True if filepath.endswith(f'.{format}') else False
+        if canBeConverted:
+            can_convert = True
             import_format = format
             break
 
-    return files_to_convert, import_format
+    return can_convert, import_format
 
 
-def copy_epubs_for_import(epub_files) -> None:
+def move_epub(isEpub) -> None:
     """Moves the epubs from the download folder to the calibre-web import folder"""
-    for file in epub_files:
-        print(f"[new-book-processor]: Moving {file}...")
-        filename = file.split('/')[-1]
-        os.system(f'cp "{file}" "{import_folder}{filename}"')
+    print(f"[new-book-processor]: Moving {filepath}...")
+    filename = filepath.split('/')[-1]
+    os.system(f'cp "{filepath}" "{import_folder}{filename}"')
 
 def empty_to_process_folder() -> None:
     """Empties the ingest folder"""
-    shutil.rmtree(ingest_folder)
-
+    os.remove(filepath)
+    subprocess.run(["find", f"{ingest_folder}", "-type", "d", "-empty", "-delete"])
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
3 Fixes added:
1. This fixes #14. Adding `-r` to `inotifywait` fixes not detecting folders within the ingest file. This bug was introduced by switching the inotify event from `create` to `close_write`, because `close_write` only gets triggered by files. Adding `-r` makes it get triggered by all folders recursively. The `--format` argument was needed to reorder the variables, because paths with spaces would mess up the variable ordering

2. d4b4d3f75d910c1585d8b8497de28aa91b3cae16 introduced a bug where folders wouldn't be deleted within ingest. Added `-d` arg to `find` for it to delete directories. Had to also add `-mindepth 1` to prevent the ingest folder itself getting deleted
 
3. Also fixes the 2nd half of #7

5.  When importing multiple files at once, each completed file will trigger inotifywatch, and the script will attempt to import all files, even the ones unfinished. **To fix this, the scripts have to individually process one file at a time.** This includes a refactor and major change of the python code. (Line 93 is needed to delete the parent folder of the book if that folder is empty. Line 92 doesn't delete the folder with the file)