### PR TITLE
Fixed some typos and chown commands

### DIFF
--- a/calibre-web-automator/check-cwa-install.sh
+++ b/calibre-web-automator/check-cwa-install.sh
@@ -35,7 +35,7 @@ fi
 echo ""
 
 if $cs && $bs && $mc; then
-    echo -e "Calibre-Web-Automater was ${GREEN}sucsessfully installed ${NC}and ${GREEN}is running properly!${NC}"
+    echo -e "Calibre-Web-Automater was ${GREEN}successfully installed ${NC}and ${GREEN}is running properly!${NC}"
 else
-    echo -e "Calibre-Web-Automater was ${RED}not installed sucsessfully${NC}, please check the logs for more information."
+    echo -e "Calibre-Web-Automater was ${RED}not installed successfully${NC}, please check the logs for more information."
 fi

--- a/calibre-web-automator/new-book-detector.sh
+++ b/calibre-web-automator/new-book-detector.sh
@@ -32,6 +32,6 @@ while read -r directory events filename; do
         chown -R abc:users "$WATCH_FOLDER"
         find "$WATCH_FOLDER/" -type f -delete
         sleep 10s
-        chown -R abc:1000 "$CALIBRE_LIBRARY"
+        chown -R abc:users "$CALIBRE_LIBRARY"
         echo "[new-book-detector]: $filename successfully moved/converted, the import & ingest folders have been emptied and are ready to go again!"
 done

--- a/calibre-web-automator/new-book-processor.py
+++ b/calibre-web-automator/new-book-processor.py
@@ -26,7 +26,7 @@ def main():
         files_to_convert, import_format = select_books_for_conversion(new_files)
         print(f"[new-book-processor]: Converting {len(files_to_convert)} file(s) from to epub format...\n")
         time_total_conversion = convert_books(files_to_convert, import_format)
-        print(f"\n[new-book-processor]: {len(files_to_convert)} conversion(s) to .epub format completed succsessfully in {time_total_conversion:.2f} seconds.")
+        print(f"\n[new-book-processor]: {len(files_to_convert)} conversion(s) to .epub format completed successfully in {time_total_conversion:.2f} seconds.")
         print("[new-book-processor]: All new epub files have now been moved to the calibre-web import folder.")
     else: # Books only need copying to the import folder
         print(f"\n[new-book-processor]: Found {len(epub_files)} epub file(s) from the most recent download.")

--- a/calibre-web-automator/setup-cwa.sh
+++ b/calibre-web-automator/setup-cwa.sh
@@ -34,10 +34,7 @@ cp $SCRIPT_DIR/cover-enforcer.py /etc/calibre-web-automator/cover-enforcer.py
 cp $SCRIPT_DIR/cwa_db.py /etc/calibre-web-automator/cwa_db.py
 cp $SCRIPT_DIR/convert-library.py /etc/calibre-web-automator/convert-library.py
 
-# Change permissions of /etc/calibre-web-automator/
-chown -R abc:1000 /etc/calibre-web-automator
-
-# Make sure other sctipts are executable and permissions are correct
+# Make sure other scripts are executable and permissions are correct
 chown -R abc:users /config
 chown -R abc:users /etc/calibre-web-automator
 
@@ -92,7 +89,7 @@ touch /etc/s6-overlay/s6-rc.d/user/contents.d/metadata-change-detector
 
 # Setup completion notification
 echo ""
-echo -e "======== ${GREEN}SUCSESS${NC}: Calibre-Web-Automator Setup Complete! ========"
+echo -e "======== ${GREEN}SUCCESS${NC}: Calibre-Web-Automator Setup Complete! ========"
 echo ""
 echo " - Please restart the container so the changes will take effect."
 echo " - Do so by typing 'exit', presing enter, then running the docker command:"


### PR DESCRIPTION
I fixed some small user facing typos. 

I also removed what looks like a redundant chown command, and I changed another one to be consistent with the rest. I noticed some permission issues because the container is running as abc:users, but it is creating book folders using abc:1000.

I'm no programmer, so I apologize if there is a reason to use 1000 that I missed somewhere.