### PR TITLE
Fix folder recursion auto import issue when moving folders (not copy); Fix new-book-detector.sh adding entire directory 

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,7 @@ services:
 7. Add books by having them placed in the folder you bound to `cwa-book-ingest` in your Docker Compose
 
 **⚠️ ATTENTION ⚠️**
-  - _Downloading torrent files directly into `/cwa-book-ingest` is currently not supported. It will cause duplicate imports and potentially a corrupt database. This is currently being investigated_
-  - _The import system doesn't fully work with subdirectories within `/cwa-book-ingest`. Copying folders with books into `/cwa-book-ingest` will work, but not when moving them. This is currently being investigated. Workaround: Move/copy the books directly into `/cwa-book-ingest` without folders_
+  - _Downloading files directly into `/cwa-book-ingest` is not supported. It can cause duplicate imports and potentially a corrupt database. It is recommended to first download the books completely, then transfer them to `/cwa-book-ingest` to avoid any issues_
 #### Default Admin Login:
 > **Username:** admin\
 > **Password:** admin123
@@ -270,9 +269,7 @@ This wouldn't be my preferred method but if you never really touch your containe
 ## Adding Books to Your Library
 - Simply move your newly downloaded or existing eBook files to the ingest folder which is `/cwa-book-ingest` by default or whatever you designated during setup if using the Script Install method. Anything you place in that folder will be automatically analysed, converted if necessary and then imported into your Calibre-Web library.
     - **⚠️ ATTENTION ⚠️**
-      - _Downloading torrent files directly into `/cwa-book-ingest` is currently not supported. It will cause duplicate imports and potentially a corrupt database. This is currently being investigated_
-      - _The import system doesn't fully work with subdirectories within `/cwa-book-ingest`. Copying folders with books into `/cwa-book-ingest` will work, but not when moving them. This is currently being investigated. Workaround: Move/copy the books directly into `/cwa-book-ingest` without folders_
-    - I personally use a script that my instance of qBittorrent will automatically execute upon finishing a download with the category **'books'** to fully automate the process however there's an infinite number of configurations out there so do whatever works best for your needs!
+      - _Downloading files directly into `/cwa-book-ingest` is not supported. It can cause duplicate imports and potentially a corrupt database. It is recommended to first download the books completely, then transfer them to `/cwa-book-ingest` to avoid any issues_
 ## The Cover-Enforcer CLI Tool
 ~~~
 usage: cover-enforcer [-h] [--log LOG] [--dir DIR] [-all] [-list] [-history] [-paths] [-v]

--- a/calibre-web-automator/new-book-detector.sh
+++ b/calibre-web-automator/new-book-detector.sh
@@ -19,7 +19,7 @@ add_to_calibre() {
     CALIBREDB="/usr/bin/calibredb"
     
     # Run calibredb command to add the new eBook to the database
-    $CALIBREDB add -r $WATCH_FOLDER --library-path="$CALIBRE_LIBRARY"
+    $CALIBREDB add -r "$1" --library-path="$CALIBRE_LIBRARY"
     echo "[new-book-detector] Added $1 to Calibre database"
 }
 

--- a/calibre-web-automator/new-book-processor.py
+++ b/calibre-web-automator/new-book-processor.py
@@ -5,7 +5,7 @@ import time
 import subprocess
 
 supported_book_formats = ['azw', 'azw3', 'azw4', 'cbz', 'cbr', 'cb7', 'cbc', 'chm', 'djvu', 'docx', 'epub', 'fb2', 'fbz', 'html', 'htmlz', 'lit', 'lrf', 'mobi', 'odt', 'pdf', 'prc', 'pdb', 'pml', 'rb', 'rtf', 'snb', 'tcr', 'txtz']
-hierarchy_of_succsess = ['lit', 'mobi', 'azw', 'epub', 'azw3', 'fb2', 'fbz', 'azw4',  'prc', 'odt', 'lrf', 'pdb',  'cbz', 'pml', 'rb', 'cbr', 'cb7', 'cbc', 'chm', 'djvu', 'snb', 'tcr', 'pdf', 'docx', 'rtf', 'html', 'htmlz', 'txtz']
+hierarchy_of_success = ['lit', 'mobi', 'azw', 'epub', 'azw3', 'fb2', 'fbz', 'azw4',  'prc', 'odt', 'lrf', 'pdb',  'cbz', 'pml', 'rb', 'cbr', 'cb7', 'cbc', 'chm', 'djvu', 'snb', 'tcr', 'pdf', 'docx', 'rtf', 'html', 'htmlz', 'txtz']
 
 dirs = {}
 with open('/etc/calibre-web-automator/dirs.json', 'r') as f:
@@ -14,20 +14,28 @@ with open('/etc/calibre-web-automator/dirs.json', 'r') as f:
 # Both folders are assigned by user during setup
 import_folder = f"{dirs['import_folder']}/"
 ingest_folder = f"{dirs['ingest_folder']}/" # Dir where new files are looked for to process and subsequently deleted
-filepath = sys.argv[1] # path of the book we're targeting
+arg = sys.argv[1] # path of the book we're targeting
 
-def main():
+def main(filepath = arg):
+    # Check if is a directory. Inotifywait won't detect files inside folders if the folder was moved rather than copied
+    if os.path.isdir(filepath):
+        print(os.listdir(filepath))
+        for filename in os.listdir(filepath):
+            f = os.path.join(filepath, filename)
+            main(f)
+        return
+
     t_start = time.time()
 
     is_epub = True if filepath.endswith('.epub') else False
 
     if not is_epub: # Books require conversion
         print("\n[new-book-processor]: No epub files found in the current directory. Starting conversion process...")
-        can_convert, import_format = can_convert_check()
+        can_convert, import_format = can_convert_check(filepath)
         print(f"[new-book-processor]: Converting file from to epub format...\n")
         
         if (can_convert):
-            time_total_conversion = convert_book(import_format)
+            time_total_conversion = convert_book(filepath, import_format)
             print(f"\n[new-book-processor]: conversion to .epub format completed succsessfully in {time_total_conversion:.2f} seconds.")
             print("[new-book-processor]: All new epub files have now been moved to the calibre-web import folder.")
         else:
@@ -36,17 +44,16 @@ def main():
     else: # Books only need copying to the import folder
         print(f"\n[new-book-processor]: Found  epub file from the most recent download.")
         print("[new-book-processor]: Moving resulting files to calibre-web import folder...\n")
-        move_epub(is_epub)
+        move_epub(filepath, is_epub)
         print(f"[new-book-processor]: Copied epub file to calibre-web import folder.")
 
     t_end = time.time()
     running_time = t_end - t_start
 
     print(f"[new-book-processor]: Processing of new files completed in {running_time:.2f} seconds.\n\n")
-    empty_to_process_folder()
-    sys.exit(1)
+    delete_file(filepath)
 
-def convert_book(import_format: str) -> float:
+def convert_book(filepath, import_format: str) -> float:
     """Uses the following terminal command to convert the books provided using the calibre converter tool:\n\n--- ebook-convert myfile.input_format myfile.output_format\n\nAnd then saves the resulting epubs to the calibre-web import folder."""
     t_convert_total_start = time.time()
     t_convert_book_start = time.time()
@@ -63,13 +70,13 @@ def convert_book(import_format: str) -> float:
     return time_total_conversion
 
 
-def can_convert_check():
+def can_convert_check(filepath):
     """When no epubs are detected in the download, this function will go through the list of new files 
     and check for the format the are in that has the highest chance of successful conversion according to the input format hierarchy list 
     provided by calibre"""
     can_convert = False
     import_format = ''
-    for format in hierarchy_of_succsess:
+    for format in hierarchy_of_success:
         can_be_converted = True if filepath.endswith(f'.{format}') else False
         if can_be_converted:
             can_convert = True
@@ -79,13 +86,13 @@ def can_convert_check():
     return can_convert, import_format
 
 
-def move_epub(is_epub) -> None:
+def move_epub(filepath, is_epub) -> None:
     """Moves the epubs from the download folder to the calibre-web import folder"""
     print(f"[new-book-processor]: Moving {filepath}...")
     filename = filepath.split('/')[-1]
     os.system(f'cp "{filepath}" "{import_folder}{filename}"')
 
-def empty_to_process_folder() -> None:
+def delete_file(filepath) -> None:
     """Empties the ingest folder"""
     os.remove(filepath)
     subprocess.run(["find", f"{ingest_folder}", "-type", "d", "-empty", "-delete"])


### PR DESCRIPTION
As above, when moving a folder full a book files, it will not detect the files inside the moved folder. This PR adds code to the python file to loop through the detected folder

I also have fixed an issue that I have missed where new-book-detector would try adding the entire cwa-import dir into the calibre db, and I have forgotten to change it so it moves each individual file it detects. This fixed auto import potentially duplicating imports I think due to new-book-detector.sh adding the entire directory for every file added

Obviously, please test if this works for you. For me, it has fixed both moving and copying folders into auto-import. I have also updated the README to reflect these changes