### PR TITLE
Remove sleep 10s in new-book-detector

### DIFF
--- a/calibre-web-automator/new-book-detector.sh
+++ b/calibre-web-automator/new-book-detector.sh
@@ -32,7 +32,6 @@ while read -r events filepath; do
         chown -R abc:users "$WATCH_FOLDER"
         #find "$WATCH_FOLDER/" -mindepth 1 -type f,d -delete
         rm "$filepath"
-        sleep 10s
         chown -R abc:1000 "$CALIBRE_LIBRARY"
         echo "[new-book-detector]: $filepath successfully moved/converted, the Ingest Folder has been emptied and is ready"
 done


### PR DESCRIPTION
This doesn't seem to be important anymore and also makes importing extremely slow for bulk downloads. Maybe add it as a small release 1.2.2-1?